### PR TITLE
script: fix clone path to prebuilts/vndk/v32

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -24,7 +24,7 @@ git clone https://github.com/sounddrill31/local_manifests --depth 1 -b lmodroid-
 
 # Sync the repositories
 repo sync -c -j$(nproc --all) --force-sync --no-clone-bundle --no-tags && \ 
-git clone https://android.googlesource.com/platform/prebuilts/vndk/v32 platform/prebuilts/vndk/v32
+if [ ! -d "prebuilts/vndk/v32" ]; then git clone https://android.googlesource.com/platform/prebuilts/vndk/v32 prebuilts/vndk/v32; fi
 # Set up build environment
 source build/envsetup.sh && \
 


### PR DESCRIPTION
* also add logic to only clone the repo if the path dosen`t exist